### PR TITLE
hopefully this works

### DIFF
--- a/data/_ui/interfaces.txt
+++ b/data/_ui/interfaces.txt
@@ -185,10 +185,10 @@ interface "map detail panel"
 interface "map planet card"
 	value "text start" 13
 	value "category size" 20
-	value "height" 150
+	value "categories" 5
+	value "extra height" 30
 	value "width" 235
 	value "planet icon max size" 100
-	value "categories" 6
 
 
 

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -190,7 +190,6 @@ bool MapDetailPanel::Scroll(double dx, double dy)
 // Only override the ones you need; the default action is to return false.
 bool MapDetailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress)
 {
-	const Interface *planetCardInterface = GameData::Interfaces().Get("map planet card");
 	const double planetCardHeight = MapPlanetCard::Height();
 	if((key == SDLK_TAB || command.Has(Command::JUMP)) && player.Flagship())
 	{

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -191,7 +191,7 @@ bool MapDetailPanel::Scroll(double dx, double dy)
 bool MapDetailPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress)
 {
 	const Interface *planetCardInterface = GameData::Interfaces().Get("map planet card");
-	const double planetCardHeight = planetCardInterface->GetValue("height");
+	const double planetCardHeight = MapPlanetCard::Height();
 	if((key == SDLK_TAB || command.Has(Command::JUMP)) && player.Flagship())
 	{
 		// Clear the selected planet, if any.
@@ -347,7 +347,7 @@ bool MapDetailPanel::Click(int x, int y, int clicks)
 	const double planetCardWidth = planetCardInterface->GetValue("width");
 	const Interface *mapInterface = GameData::Interfaces().Get("map detail panel");
 	const double arrowOffset = mapInterface->GetValue("arrow x offset");
-	const double planetCardHeight = planetCardInterface->GetValue("height");
+	const double planetCardHeight = MapPlanetCard::Height();
 	if(x < Screen::Left() + 160)
 	{
 		// The player clicked in the left-hand interface. This could be the system
@@ -481,6 +481,7 @@ void MapDetailPanel::GeneratePlanetCards(const System &system)
 	planetCards.clear();
 	SetScroll(0.);
 	unsigned number = 0;
+	MapPlanetCard::ResetSize();
 	for(const StellarObject &object : system.Objects())
 		if(object.HasSprite() && object.HasValidPlanet())
 		{
@@ -647,7 +648,7 @@ void MapDetailPanel::DrawInfo()
 	const Color &back = *GameData::Colors().Get("map side panel background");
 
 	const Interface *planetCardInterface = GameData::Interfaces().Get("map planet card");
-	double planetHeight = planetCardInterface->GetValue("height");
+	double planetCardHeight = MapPlanetCard::Height();
 	double planetWidth = planetCardInterface->GetValue("width");
 	const Interface *mapInterface = GameData::Interfaces().Get("map detail panel");
 	double minPlanetPanelHeight = mapInterface->GetValue("min planet panel height");
@@ -661,7 +662,7 @@ void MapDetailPanel::DrawInfo()
 	// Draw the panel for the planets. If the system was not visited, no planets will be shown.
 	const double minimumSize = max(minPlanetPanelHeight, Screen::Height() - bottomGovY - systemSprite->Height());
 	planetPanelHeight = hasVisited ? min(min(minimumSize, maxPlanetPanelHeight),
-		(planetCards.size()) * planetHeight) : 0.;
+		(planetCards.size()) * planetCardHeight) : 0.;
 	Point size(planetWidth, planetPanelHeight);
 	// This needs to fill from the start of the screen.
 	FillShader::Fill(Screen::TopLeft() + Point(size.X() / 2., size.Y() / 2.),
@@ -680,10 +681,10 @@ void MapDetailPanel::DrawInfo()
 			// Fit another planet, if we can, also give scrolling freedom to reach the planets at the end.
 			// This updates the location of the card so it needs to be called before AvailableSpace().
 			card.DrawIfFits(uiPoint);
-			uiPoint.Y() += planetHeight;
+			uiPoint.Y() += planetCardHeight;
 
 			// Do this all of the time so we can scroll if an element is partially shown.
-			maxScroll += (planetHeight - card.AvailableSpace());
+			maxScroll += (planetCardHeight - card.AvailableSpace());
 		}
 
 		// Edges:

--- a/source/MapPlanetCard.cpp
+++ b/source/MapPlanetCard.cpp
@@ -29,12 +29,13 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "Politics.h"
 #include "Screen.h"
 #include "SpriteShader.h"
+#include "System.h"
 #include "StellarObject.h"
 #include "text/WrappedText.h"
 
 using namespace std;
 
-std::string MapPlanetCard::lastGovernmentName;
+std::string MapPlanetCard::systemGovernmentName;
 bool MapPlanetCard::hasGovernments = false;
 
 
@@ -47,13 +48,10 @@ MapPlanetCard::MapPlanetCard(const StellarObject &object, unsigned number, bool 
 	hasShipyard = planet->HasShipyard();
 	hasOutfitter = planet->HasOutfitter();
 	governmentName = planet->GetGovernment()->GetName();
-	if(planet->IsInhabited())
-	{
-		if(lastGovernmentName.empty())
-			lastGovernmentName = governmentName;
-		else if(governmentName != lastGovernmentName)
-			hasGovernments = true;
-	}
+	if(systemGovernmentName.empty())
+		systemGovernmentName = planet->GetSystem()->GetGovernment()->GetName();
+	if(planet->GetGovernment()->GetName() != "Uninhabited" && governmentName != systemGovernmentName)
+		hasGovernments = true;
 
 	if(!hasSpaceport)
 		reputationLabel = "No Spaceport";
@@ -278,7 +276,7 @@ double MapPlanetCard::Height()
 
 void MapPlanetCard::ResetSize()
 {
-	lastGovernmentName.clear();
+	systemGovernmentName.clear();
 	hasGovernments = false;
 }
 

--- a/source/MapPlanetCard.cpp
+++ b/source/MapPlanetCard.cpp
@@ -106,7 +106,7 @@ MapPlanetCard::ClickAction MapPlanetCard::Click(int x, int y, int clicks)
 
 			// The first category is the planet name and is not selectable.
 			if(x > Screen::Left() + planetIconMaxSize &&
-					relativeY > textStart + categorySize && relativeY < textStart + categorySize * categories)
+					relativeY > textStart + categorySize && relativeY < textStart + categorySize * (categories + hasGovernments))
 				selectedCategory = (relativeY - textStart - categorySize) / categorySize;
 			else
 				clickAction = ClickAction::SELECTED;
@@ -116,7 +116,8 @@ MapPlanetCard::ClickAction MapPlanetCard::Click(int x, int y, int clicks)
 										MapPanel::SHOW_VISITED};
 			if(clickAction != ClickAction::SELECTED)
 			{
-				clickAction = static_cast<ClickAction>(SHOW[selectedCategory]);
+				// If there are no governments shown, the first category is the reputation.
+				clickAction = static_cast<ClickAction>(SHOW[selectedCategory + !hasGovernments]);
 				// Double clicking results in going to the shipyard/outfitter.
 				if(clickAction == ClickAction::SHOW_SHIPYARD && clicks > 1)
 					clickAction = ClickAction::GOTO_SHIPYARD;
@@ -201,17 +202,17 @@ bool MapPlanetCard::DrawIfFits(const Point &uiPoint)
 			font.Draw(governmentName, uiPoint + Point(margin, textStart + categorySize),
 				governmentName == "Uninhabited" ? faint : medium);
 		if(FitsCategory(4.))
-			font.Draw(reputationLabel, uiPoint + Point(margin, textStart + categorySize * 2.),
+			font.Draw(reputationLabel, uiPoint + Point(margin, textStart + categorySize * (1. + hasGovernments)),
 				hasSpaceport ? medium : faint);
 		if(FitsCategory(3.))
-			font.Draw("Shipyard", uiPoint + Point(margin, textStart + categorySize * 3.),
+			font.Draw("Shipyard", uiPoint + Point(margin, textStart + categorySize * (2. + hasGovernments)),
 				hasShipyard ? medium : faint);
 		if(FitsCategory(2.))
-			font.Draw("Outfitter", uiPoint + Point(margin, textStart + categorySize * 4.),
+			font.Draw("Outfitter", uiPoint + Point(margin, textStart + categorySize * (3. + hasGovernments)),
 				hasOutfitter ? medium : faint);
 		if(FitsCategory(1.))
 			font.Draw(hasVisited ? "(has been visited)" : "(not yet visited)",
-				uiPoint + Point(margin, textStart + categorySize * 5.), dim);
+				uiPoint + Point(margin, textStart + categorySize * (4. + hasGovernments)), dim);
 
 		// Draw the arrow pointing to the selected category.
 		if(FitsCategory(categories - (selectedCategory + 1.)))

--- a/source/MapPlanetCard.cpp
+++ b/source/MapPlanetCard.cpp
@@ -194,12 +194,12 @@ bool MapPlanetCard::DrawIfFits(const Point &uiPoint)
 		};
 
 		// Draw the name of the planet.
-		if(FitsCategory(6.))
+		if(FitsCategory(categories + hasGovernments))
 			font.Draw({ planetName, alignLeft }, uiPoint + Point(0, textStart), isSelected ? medium : dim);
 
 		// Draw the government name, reputation, shipyard, outfitter and visited.
 		const double margin = mapInterface->GetValue("text margin");
-		if(FitsCategory(5.))
+		if(hasGovernments && FitsCategory(categories))
 			font.Draw(governmentName, uiPoint + Point(margin, textStart + categorySize),
 				governmentName == "Uninhabited" ? faint : medium);
 		if(FitsCategory(4.))

--- a/source/MapPlanetCard.cpp
+++ b/source/MapPlanetCard.cpp
@@ -44,6 +44,13 @@ MapPlanetCard::MapPlanetCard(const StellarObject &object, unsigned number, bool 
 	hasShipyard = planet->HasShipyard();
 	hasOutfitter = planet->HasOutfitter();
 	governmentName = planet->GetGovernment()->GetName();
+	if(governmentName != "Uninhabited")
+	{
+		if(!lastGovernmentName.empty() && governmentName != lastGovernmentName)
+			hasGovernments = true;
+		else
+			lastGovernmentName = governmentName;
+	}
 
 	if(!hasSpaceport)
 		reputationLabel = "No Spaceport";
@@ -141,7 +148,7 @@ bool MapPlanetCard::DrawIfFits(const Point &uiPoint)
 		const auto alignLeft = Layout(planetCardInterface->GetValue("width") - planetIconMaxSize, Truncate::BACK);
 
 		// Height of one MapPlanetCard element.
-		const double height = planetCardInterface->GetValue("height");
+		const double height = Height();
 		// Point at which the text starts (after the top margin), at first there is the planet's name,
 		// and then it is divided into clickable categories of the same size.
 		const double textStart = planetCardInterface->GetValue("text start");
@@ -256,6 +263,24 @@ void MapPlanetCard::Select(bool select)
 
 
 
+double MapPlanetCard::Height()
+{
+	const Interface *planetCardInterface = GameData::Interfaces().Get("map planet card");
+	return planetCardInterface->GetValue("extra height") +
+		(planetCardInterface->GetValue("categories") + hasGovernments) *
+		planetCardInterface->GetValue("category size");
+}
+
+
+
+void MapPlanetCard::ResetSize()
+{
+	lastGovernmentName.empty();
+	hasGovernments = false;
+}
+
+
+
 void MapPlanetCard::Highlight(double availableSpace) const
 {
 	const Interface *planetCardInterface = GameData::Interfaces().Get("map planet card");
@@ -269,20 +294,17 @@ void MapPlanetCard::Highlight(double availableSpace) const
 
 double MapPlanetCard::AvailableTopSpace() const
 {
-	const Interface *planetCardInterface = GameData::Interfaces().Get("map planet card");
-	const double height = planetCardInterface->GetValue("height");
+	const double height = Height();
 	return min(height, max(0., (number + 1) * height - MapDetailPanel::GetScroll()));
 }
 
 
 
-double MapPlanetCard::AvailableBottomSpace() const
+double MapPlanetCard::AvailableBottomSpace()
 {
 	const Interface *mapInterface = GameData::Interfaces().Get("map detail panel");
 	double maxPlanetPanelHeight = mapInterface->GetValue("max planet panel height");
-	const Interface *planetCardInterface = GameData::Interfaces().Get("map planet card");
-	double height = planetCardInterface->GetValue("height");
 
-	return min(height, max(0., Screen::Top() +
+	return min(Height(), max(0., Screen::Top() +
 		min(MapDetailPanel::PlanetPanelHeight(), maxPlanetPanelHeight) - yCoordinate));
 }

--- a/source/MapPlanetCard.cpp
+++ b/source/MapPlanetCard.cpp
@@ -300,7 +300,7 @@ double MapPlanetCard::AvailableTopSpace() const
 
 
 
-double MapPlanetCard::AvailableBottomSpace()
+double MapPlanetCard::AvailableBottomSpace() const
 {
 	const Interface *mapInterface = GameData::Interfaces().Get("map detail panel");
 	double maxPlanetPanelHeight = mapInterface->GetValue("max planet panel height");

--- a/source/MapPlanetCard.cpp
+++ b/source/MapPlanetCard.cpp
@@ -34,6 +34,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 using namespace std;
 
+std::string MapPlanetCard::lastGovernmentName;
+bool MapPlanetCard::hasGovernments = false;
+
 
 
 MapPlanetCard::MapPlanetCard(const StellarObject &object, unsigned number, bool hasVisited)

--- a/source/MapPlanetCard.cpp
+++ b/source/MapPlanetCard.cpp
@@ -278,7 +278,7 @@ double MapPlanetCard::Height()
 
 void MapPlanetCard::ResetSize()
 {
-	lastGovernmentName.empty();
+	lastGovernmentName.clear();
 	hasGovernments = false;
 }
 

--- a/source/MapPlanetCard.cpp
+++ b/source/MapPlanetCard.cpp
@@ -47,12 +47,12 @@ MapPlanetCard::MapPlanetCard(const StellarObject &object, unsigned number, bool 
 	hasShipyard = planet->HasShipyard();
 	hasOutfitter = planet->HasOutfitter();
 	governmentName = planet->GetGovernment()->GetName();
-	if(governmentName != "Uninhabited")
+	if(planet->IsInhabited())
 	{
-		if(!lastGovernmentName.empty() && governmentName != lastGovernmentName)
-			hasGovernments = true;
-		else
+		if(lastGovernmentName.empty())
 			lastGovernmentName = governmentName;
+		else if(governmentName != lastGovernmentName)
+			hasGovernments = true;
 	}
 
 	if(!hasSpaceport)

--- a/source/MapPlanetCard.h
+++ b/source/MapPlanetCard.h
@@ -96,7 +96,7 @@ private:
 	// The currently select category (outfitter, shipyard, ...)
 	unsigned selectedCategory = 0;
 
-	static std::string lastGovernmentName;
+	static std::string systemGovernmentName;
 	static bool hasGovernments;
 };
 

--- a/source/MapPlanetCard.h
+++ b/source/MapPlanetCard.h
@@ -61,6 +61,9 @@ public:
 
 	void Select(bool select = true);
 
+	static double Height();
+
+	static void ResetSize();
 
 protected:
 	// Highlight this card; this is to be called when it is selected.
@@ -92,6 +95,9 @@ private:
 	const std::string &planetName;
 	// The currently select category (outfitter, shipyard, ...)
 	unsigned selectedCategory = 0;
+
+	static std::string lastGovernmentName;
+	static bool hasGovernments;
 };
 
 


### PR DESCRIPTION
basically does the extra height think we talked about, but also works with all planets having the same size that's sometimes bigger or smaller depending on if there are different non uninhabited governments present in planets in the system

that could be changed without too much difficulty to showing only non uninhabited but I like it better this way not showing when not needed

note: I have NOT tested this yet because I dont have my main pc rn
also maybe I should do a mix of both and still not show uninhabited when both mix but idk if its worth it