### PR TITLE
Don't blanket impact all WrappedText

### DIFF
--- a/data/_ui/tooltips.txt
+++ b/data/_ui/tooltips.txt
@@ -1631,11 +1631,10 @@ tip "Notify on destination"
 tip "Save message log"
 	`Include message logs in pilot files so they are not lost when closing the game or reloading the save file. This will increase save file sizes and may increase load times. The stored log history can be cleared from the message log panel.`
 
-tip "Alignment override"
-	`Sets the horizontal alignment of text paragraphs across the UI.`
-	`- "off": a default will be used that can differ for each location in the UI. Most locations use justified text by default, with some using left alignment.`
+tip "Text alignment"
+	`Sets the horizontal text alignment of paragraphs across the UI.`
 	`- "left": align to the left.`
-	`- "right: align to the right.`
+	`- "right": align to the right.`
 	`- "center": center the text.`
 	`- "justified": add extra space between words to align with both margins.`
 

--- a/source/ConversationPanel.cpp
+++ b/source/ConversationPanel.cpp
@@ -262,6 +262,14 @@ void ConversationPanel::Draw()
 
 
 
+void ConversationPanel::UpdateTextDisplay()
+{
+	for(auto &paragraph : text)
+		paragraph.SetAlignment(Preferences::GetTextAlignment());
+}
+
+
+
 // Handle key presses.
 bool ConversationPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, bool isNewPress)
 {
@@ -559,7 +567,7 @@ int ConversationPanel::MapChoice(int n) const
 ConversationPanel::Paragraph::Paragraph(const string &text, const Sprite *scene, bool isFirst)
 	: scene(scene), isFirst(isFirst)
 {
-	wrap.SetAlignment(Alignment::JUSTIFIED);
+	wrap.SetAlignment(Preferences::GetTextAlignment());
 	wrap.SetWrapWidth(WIDTH);
 	wrap.SetFont(FontSet::Get(14));
 
@@ -600,4 +608,11 @@ Point ConversationPanel::Paragraph::Draw(Point point, const Color &color) const
 	wrap.Draw(point, color);
 	point.Y() += wrap.Height();
 	return point;
+}
+
+
+
+void ConversationPanel::Paragraph::SetAlignment(Alignment alignment)
+{
+	wrap.SetAlignment(alignment);
 }

--- a/source/ConversationPanel.h
+++ b/source/ConversationPanel.h
@@ -56,6 +56,8 @@ public:
 	// Draw this panel.
 	virtual void Draw() override;
 
+	virtual void UpdateTextDisplay() override;
+
 
 protected:
 	// Event handlers.
@@ -97,6 +99,7 @@ private:
 		// Draw this paragraph at the given point, and return the point that the
 		// next paragraph below this one should be drawn at.
 		Point Draw(Point point, const Color &color) const;
+		void SetAlignment(Alignment alignment);
 
 	private:
 		const Sprite *scene = nullptr;

--- a/source/CustomEvents.cpp
+++ b/source/CustomEvents.cpp
@@ -19,13 +19,15 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 namespace {
 	Uint32 resize = -1;
+	Uint32 adjustText = -1;
 }
 
 
 
 void CustomEvents::Init()
 {
-	resize = SDL_RegisterEvents(1);
+	resize = SDL_RegisterEvents(2);
+	adjustText = resize + 1;
 }
 
 
@@ -42,5 +44,22 @@ void CustomEvents::SendResize()
 {
 	SDL_Event event;
 	event.type = GetResize();
+	SDL_PushEvent(&event);
+}
+
+
+
+Uint32 CustomEvents::GetAdjustText()
+{
+	assert(adjustText != static_cast<Uint32>(-1) && "Custom events must be registered");
+	return adjustText;
+}
+
+
+
+void CustomEvents::SendAdjustText()
+{
+	SDL_Event event;
+	event.type = GetAdjustText();
 	SDL_PushEvent(&event);
 }

--- a/source/CustomEvents.h
+++ b/source/CustomEvents.h
@@ -28,4 +28,9 @@ public:
 	static Uint32 GetResize();
 	// Send the custom resize event.
 	static void SendResize();
+
+	// Get the registered ID of the custom adjust text event.
+	static Uint32 GetAdjustText();
+	// Send the custom adjust text event.
+	static void SendAdjustText();
 };

--- a/source/DialogPanel.cpp
+++ b/source/DialogPanel.cpp
@@ -28,6 +28,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "MapDetailPanel.h"
 #include "PlayerInfo.h"
 #include "Point.h"
+#include "Preferences.h"
 #include "Screen.h"
 #include "shift.h"
 #include "image/Sprite.h"
@@ -264,6 +265,13 @@ bool DialogPanel::AllowsFastForward() const noexcept
 
 
 
+void DialogPanel::UpdateTextDisplay()
+{
+	text->SetAlignment(Preferences::GetTextAlignment());
+}
+
+
+
 DialogPanel::DialogPanel(DialogInit &init)
 	: voidFun(std::move(init.voidFun)),
 	boolFun(std::move(init.boolFun)),
@@ -299,7 +307,7 @@ DialogPanel::DialogPanel(DialogInit &init)
 	cancelText = isMission ? "Decline" : "Cancel";
 
 	text = make_shared<TextArea>();
-	text->SetAlignment(Alignment::JUSTIFIED);
+	text->SetAlignment(Preferences::GetTextAlignment());
 	text->SetFont(FontSet::Get(14));
 	text->SetTruncate(init.truncate);
 	text->SetText(init.message);

--- a/source/DialogPanel.h
+++ b/source/DialogPanel.h
@@ -159,6 +159,8 @@ public:
 	// Some dialogs allow fast-forward to stay active.
 	bool AllowsFastForward() const noexcept final;
 
+	virtual void UpdateTextDisplay() override;
+
 
 protected:
 	class DialogInit {

--- a/source/HailPanel.cpp
+++ b/source/HailPanel.cpp
@@ -305,7 +305,7 @@ void HailPanel::Draw()
 
 	// Draw the current message.
 	WrappedText wrap;
-	wrap.SetAlignment(Alignment::JUSTIFIED);
+	wrap.SetAlignment(Preferences::GetTextAlignment());
 	wrap.SetWrapWidth(330);
 	wrap.SetFont(FontSet::Get(14));
 	wrap.Wrap(message);

--- a/source/ItemInfoDisplay.cpp
+++ b/source/ItemInfoDisplay.cpp
@@ -21,6 +21,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "text/FontSet.h"
 #include "text/Format.h"
 #include "GameData.h"
+#include "Preferences.h"
 #include "Rectangle.h"
 #include "Screen.h"
 #include "text/Table.h"
@@ -33,10 +34,10 @@ using namespace std;
 
 
 ItemInfoDisplay::ItemInfoDisplay()
-	: tooltip(WIDTH, Alignment::JUSTIFIED, Tooltip::Direction::DOWN_LEFT, Tooltip::Corner::TOP_LEFT,
+	: tooltip(WIDTH, Alignment::LEFT, Tooltip::Direction::DOWN_LEFT, Tooltip::Corner::TOP_LEFT,
 		GameData::Colors().Get("tooltip background"), GameData::Colors().Get("medium"))
 {
-	description.SetAlignment(Alignment::JUSTIFIED);
+	description.SetAlignment(Preferences::GetTextAlignment());
 	description.SetWrapWidth(WIDTH - 20);
 	description.SetFont(FontSet::Get(14));
 }

--- a/source/LogbookPanel.cpp
+++ b/source/LogbookPanel.cpp
@@ -138,7 +138,7 @@ void LogbookPanel::Draw()
 
 	// Parameters for drawing the main text:
 	WrappedText wrap(font);
-	wrap.SetAlignment(Alignment::JUSTIFIED);
+	wrap.SetAlignment(Preferences::GetTextAlignment());
 	wrap.SetWrapWidth(TEXT_WIDTH - 2. * PAD);
 
 	// Draw the main text.

--- a/source/MapDetailPanel.cpp
+++ b/source/MapDetailPanel.cpp
@@ -515,7 +515,7 @@ void MapDetailPanel::InitTextArea()
 	description = make_shared<TextArea>();
 	description->SetFont(FontSet::Get(14));
 	description->SetColor(*GameData::Colors().Get("medium"));
-	description->SetAlignment(Alignment::JUSTIFIED);
+	description->SetAlignment(Preferences::GetTextAlignment());
 	ResizeTextArea();
 }
 

--- a/source/MessageLogPanel.cpp
+++ b/source/MessageLogPanel.cpp
@@ -80,7 +80,7 @@ void MessageLogPanel::Draw()
 
 		// Parameters for drawing messages:
 		WrappedText messageLine(font);
-		messageLine.SetAlignment(Alignment::LEFT);
+		messageLine.SetAlignment(Preferences::GetTextAlignment());
 		messageLine.SetWrapWidth(width - 2. * PAD);
 
 		// Draw messages.

--- a/source/MissionPanel.cpp
+++ b/source/MissionPanel.cpp
@@ -674,7 +674,7 @@ void MissionPanel::InitTextArea()
 {
 	description = make_shared<TextArea>();
 	description->SetFont(FontSet::Get(14));
-	description->SetAlignment(Alignment::JUSTIFIED);
+	description->SetAlignment(Preferences::GetTextAlignment());
 	description->SetColor(*GameData::Colors().Get("bright"));
 	ResizeTextArea();
 }

--- a/source/Panel.cpp
+++ b/source/Panel.cpp
@@ -291,6 +291,15 @@ void Panel::DoResize()
 
 
 
+void Panel::DoUpdateTextDisplay()
+{
+	UpdateTextDisplay();
+	for(auto &child : children)
+		child->DoUpdateTextDisplay();
+}
+
+
+
 void Panel::SetIsFullScreen(bool set)
 {
 	isFullScreen = set;

--- a/source/Panel.cpp
+++ b/source/Panel.cpp
@@ -150,6 +150,12 @@ void Panel::UpdateTooltipActivation()
 
 
 
+void Panel::UpdateTextDisplay()
+{
+}
+
+
+
 void Panel::AddOrRemove()
 {
 	for(auto &panel : childrenToAdd)

--- a/source/Panel.h
+++ b/source/Panel.h
@@ -156,6 +156,7 @@ private:
 	void DoDraw();
 
 	void DoResize();
+	void DoUpdateTextDisplay();
 
 	// Call a method on all the children in reverse order, and then on this
 	// object. Recursion stops as soon as any child returns true.

--- a/source/Panel.h
+++ b/source/Panel.h
@@ -77,7 +77,12 @@ public:
 	// Is fast-forward allowed to be on when this panel is on top of the GUI stack?
 	virtual bool AllowsFastForward() const noexcept;
 
+	// Functions for updating Tooltip or WrappedText/TextArea objects within a panel
+	// based off of changes made to the preferences. Some panels that contain these
+	// objects may not implement these functions because the panel can't be in the
+	// UI stack when the preference is changed.
 	virtual void UpdateTooltipActivation();
+	virtual void UpdateTextDisplay();
 
 
 protected:

--- a/source/PlanetPanel.cpp
+++ b/source/PlanetPanel.cpp
@@ -37,6 +37,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "PlayerInfo.h"
 #include "PlayerInfoPanel.h"
 #include "Port.h"
+#include "Preferences.h"
 #include "Screen.h"
 #include "Ship.h"
 #include "ShipyardPanel.h"
@@ -69,7 +70,7 @@ PlanetPanel::PlanetPanel(PlayerInfo &player, function<void()> callback)
 	description = make_shared<TextArea>();
 	description->SetFont(FontSet::Get(14));
 	description->SetColor(*GameData::Colors().Get("bright"));
-	description->SetAlignment(Alignment::JUSTIFIED);
+	description->SetAlignment(Preferences::GetTextAlignment());
 	AddChild(description);
 
 	// Since the loading of landscape images is deferred, make sure that the
@@ -236,6 +237,13 @@ void PlanetPanel::Draw()
 	// after the panel's creation, such as the player accepting a mission on the Job Board.
 	if(!selectedPanel)
 		description->SetText(planet.Description().ToString());
+}
+
+
+
+void PlanetPanel::UpdateTextDisplay()
+{
+	description->SetAlignment(Preferences::GetTextAlignment());
 }
 
 

--- a/source/PlanetPanel.h
+++ b/source/PlanetPanel.h
@@ -47,6 +47,8 @@ public:
 	virtual void Step() override;
 	virtual void Draw() override;
 
+	virtual void UpdateTextDisplay() override;
+
 
 protected:
 	// Only override the ones you need; the default action is to return false.

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -15,6 +15,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "Preferences.h"
 
+#include "text/Alignment.h"
 #include "audio/Audio.h"
 #include "DataFile.h"
 #include "DataNode.h"
@@ -187,8 +188,8 @@ namespace {
 	const vector<string> AMMO_REFILL_SETTINGS = {"never", "ask", "when free", "always"};
 	int ammoRefillIndex = 1;
 
-	const vector<string> ALIGNMENT_OVERRIDE_SETTINGS = {"off", "left", "center", "right", "justified"};
-	int alignmentOverrideIndex = 0;
+	const vector<string> TEXT_ALIGNMENT_SETTINGS = {"left", "center", "right", "justified"};
+	int textAlignmentIndex = 3;
 
 	const string BLOCK_SCREEN_SAVER = "Block screen saver";
 
@@ -301,8 +302,8 @@ void Preferences::Load()
 			tributeConfirmationIndex = max<int>(0, min<int>(node.Value(1), TRIBUTE_CONFIRMATION_SETTINGS.size() - 1));
 		else if(key == "Ammo refill")
 			ammoRefillIndex = clamp<int>(node.Value(1), 0, AMMO_REFILL_SETTINGS.size() - 1);
-		else if(key == "Alignment override")
-			alignmentOverrideIndex = clamp<int>(node.Value(1), 0, ALIGNMENT_OVERRIDE_SETTINGS.size() - 1);
+		else if(key == "Text alignment")
+			textAlignmentIndex = clamp<int>(node.Value(1), 0, TEXT_ALIGNMENT_SETTINGS.size() - 1);
 #ifdef _WIN32
 		else if(key == "Title bar theme")
 			titleBarThemeIndex = clamp<int>(node.Value(1), 0, TITLE_BAR_THEME_SETTINGS.size() - 1);
@@ -390,7 +391,7 @@ void Preferences::Save()
 	out.Write("Reduce large graphics", largeGraphicsReductionIndex);
 	out.Write("Tribute confirmation", tributeConfirmationIndex);
 	out.Write("Ammo refill", ammoRefillIndex);
-	out.Write("Alignment override", alignmentOverrideIndex);
+	out.Write("Text alignment", textAlignmentIndex);
 	out.Write("previous saves", previousSaveCount);
 #ifdef _WIN32
 	if(WinVersion::SupportsDarkTheme())
@@ -1037,24 +1038,24 @@ const std::string &Preferences::AmmoRefillSetting()
 
 
 
-void Preferences::ToggleAlignmentOverride()
+void Preferences::ToggleTextAlignment()
 {
-	if(++alignmentOverrideIndex >= static_cast<int>(ALIGNMENT_OVERRIDE_SETTINGS.size()))
-		alignmentOverrideIndex = 0;
+	if(++textAlignmentIndex >= static_cast<int>(TEXT_ALIGNMENT_SETTINGS.size()))
+		textAlignmentIndex = 0;
 }
 
 
 
-Preferences::AlignmentOverride Preferences::GetAlignmentOverride()
+Alignment Preferences::GetTextAlignment()
 {
-	return static_cast<AlignmentOverride>(alignmentOverrideIndex);
+	return static_cast<Alignment>(textAlignmentIndex);
 }
 
 
 
-const string &Preferences::AlignmentOverrideSetting()
+const string &Preferences::TextAlignmentSetting()
 {
-	return ALIGNMENT_OVERRIDE_SETTINGS[alignmentOverrideIndex];
+	return TEXT_ALIGNMENT_SETTINGS[textAlignmentIndex];
 }
 
 

--- a/source/Preferences.h
+++ b/source/Preferences.h
@@ -19,6 +19,8 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <string>
 #include <vector>
 
+enum class Alignment;
+
 
 
 class Preferences {
@@ -151,14 +153,6 @@ public:
 		ASK,
 		WHEN_FREE,
 		ALWAYS
-	};
-
-	enum class AlignmentOverride : int_fast8_t {
-		OFF = 0,
-		LEFT,
-		CENTER,
-		RIGHT,
-		JUSTIFIED
 	};
 
 #ifdef _WIN32
@@ -302,9 +296,9 @@ public:
 	static const std::string &AmmoRefillSetting();
 
 	/// Text alignment override setting.
-	static void ToggleAlignmentOverride();
-	static AlignmentOverride GetAlignmentOverride();
-	static const std::string &AlignmentOverrideSetting();
+	static void ToggleTextAlignment();
+	static Alignment GetTextAlignment();
+	static const std::string &TextAlignmentSetting();
 
 	static void ToggleBlockScreenSaver();
 

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -18,6 +18,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "text/Alignment.h"
 #include "audio/Audio.h"
 #include "Color.h"
+#include "CustomEvents.h"
 #include "DialogPanel.h"
 #include "Files.h"
 #include "text/Font.h"
@@ -1463,7 +1464,7 @@ void PreferencesPanel::HandleSettingsString(const string &str, Point cursorPosit
 	else if(str == TEXT_ALIGNMENT)
 	{
 		Preferences::ToggleTextAlignment();
-		GetUI().AdjustTextDisplay();
+		CustomEvents::SendAdjustText();
 	}
 #ifdef _WIN32
 	else if(str == TITLE_BAR_THEME)

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -93,7 +93,7 @@ namespace {
 	const string BLOCK_SCREEN_SAVER = "Block screen saver";
 	const string TRIBUTE_CONFIRMATION = "Tribute confirmation";
 	const string AMMO_REFILL = "Auto refill ammo";
-	const string ALIGNMENT_OVERRIDE = "Alignment override";
+	const string TEXT_ALIGNMENT = "Text alignment";
 #ifdef _WIN32
 	const string TITLE_BAR_THEME = "Title bar theme";
 	const string WINDOW_ROUNDING = "Window rounding";
@@ -828,7 +828,7 @@ void PreferencesPanel::DrawSettings()
 		DATE_FORMAT,
 		NOTIFY_ON_DEST,
 		"Save message log",
-		ALIGNMENT_OVERRIDE,
+		TEXT_ALIGNMENT,
 #ifdef _WIN32
 		"\t",
 		"Windows Options",
@@ -1088,10 +1088,10 @@ void PreferencesPanel::DrawSettings()
 			isOn = Preferences::GetAmmoRefill() != Preferences::AmmoRefill::NEVER;
 			text = Preferences::AmmoRefillSetting();
 		}
-		else if(setting == ALIGNMENT_OVERRIDE)
+		else if(setting == TEXT_ALIGNMENT)
 		{
-			isOn = Preferences::GetAlignmentOverride() != Preferences::AlignmentOverride::OFF;
-			text = Preferences::AlignmentOverrideSetting();
+			isOn = true;
+			text = Preferences::TextAlignmentSetting();
 		}
 #ifdef _WIN32
 		else if(setting == TITLE_BAR_THEME)
@@ -1460,8 +1460,12 @@ void PreferencesPanel::HandleSettingsString(const string &str, Point cursorPosit
 		Preferences::ToggleTributeConfirmation();
 	else if(str == AMMO_REFILL)
 		Preferences::ToggleAmmoRefill();
-	else if(str == ALIGNMENT_OVERRIDE)
-		Preferences::ToggleAlignmentOverride();
+	else if(str == TEXT_ALIGNMENT)
+	{
+		Preferences::ToggleTextAlignment();
+		for(auto &panel : GetUI().Stack())
+			panel->UpdateTextDisplay();
+	}
 #ifdef _WIN32
 	else if(str == TITLE_BAR_THEME)
 		Preferences::ToggleTitleBarTheme();

--- a/source/PreferencesPanel.cpp
+++ b/source/PreferencesPanel.cpp
@@ -1463,8 +1463,7 @@ void PreferencesPanel::HandleSettingsString(const string &str, Point cursorPosit
 	else if(str == TEXT_ALIGNMENT)
 	{
 		Preferences::ToggleTextAlignment();
-		for(auto &panel : GetUI().Stack())
-			panel->UpdateTextDisplay();
+		GetUI().AdjustTextDisplay();
 	}
 #ifdef _WIN32
 	else if(str == TITLE_BAR_THEME)

--- a/source/SpaceportPanel.cpp
+++ b/source/SpaceportPanel.cpp
@@ -23,6 +23,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "News.h"
 #include "Planet.h"
 #include "PlayerInfo.h"
+#include "Preferences.h"
 #include "Random.h"
 #include "Screen.h"
 #include "TextArea.h"
@@ -40,10 +41,11 @@ SpaceportPanel::SpaceportPanel(PlayerInfo &player)
 	description = make_shared<TextArea>();
 	description->SetFont(FontSet::Get(14));
 	description->SetColor(*GameData::Colors().Get("bright"));
-	description->SetAlignment(Alignment::JUSTIFIED);
+	description->SetAlignment(Preferences::GetTextAlignment());
 	AddChild(description);
 
 	newsMessage.SetFont(FontSet::Get(14));
+	newsMessage.SetAlignment(Preferences::GetTextAlignment());
 }
 
 
@@ -123,6 +125,14 @@ void SpaceportPanel::Draw()
 		newsMessage.Draw(newsUi->GetBox(hasPortrait ? "message portrait" : "message").TopLeft(),
 			*GameData::Colors().Get("medium"));
 	}
+}
+
+
+
+void SpaceportPanel::UpdateTextDisplay()
+{
+	description->SetAlignment(Preferences::GetTextAlignment());
+	newsMessage.SetAlignment(Preferences::GetTextAlignment());
 }
 
 

--- a/source/SpaceportPanel.h
+++ b/source/SpaceportPanel.h
@@ -40,6 +40,8 @@ public:
 	virtual void Step() override;
 	virtual void Draw() override;
 
+	virtual void UpdateTextDisplay() override;
+
 
 protected:
 	virtual void Resize() override;

--- a/source/StartConditionsPanel.cpp
+++ b/source/StartConditionsPanel.cpp
@@ -86,6 +86,7 @@ StartConditionsPanel::StartConditionsPanel(PlayerInfo &player, UI &gamePanels,
 		startConditionsClickZones.emplace_back(firstRectangle + Point(0, i * entryBox.Height()), scenarios.begin() + i);
 
 	description.SetWrapWidth(descriptionBox.Width());
+	description.SetAlignment(Preferences::GetTextAlignment());
 
 	Select(startIt);
 

--- a/source/UI.cpp
+++ b/source/UI.cpp
@@ -162,6 +162,7 @@ void UI::Push(const shared_ptr<Panel> &panel)
 	toPush.push_back(panel);
 	panel->SetUI(this);
 	panel->DoResize();
+	panel->UpdateTextDisplay();
 }
 
 

--- a/source/UI.cpp
+++ b/source/UI.cpp
@@ -162,7 +162,7 @@ void UI::Push(const shared_ptr<Panel> &panel)
 	toPush.push_back(panel);
 	panel->SetUI(this);
 	panel->DoResize();
-	panel->UpdateTextDisplay();
+	panel->DoUpdateTextDisplay();
 }
 
 
@@ -288,6 +288,14 @@ void UI::AdjustViewport() const
 {
 	for(auto &it : stack)
 		it->DoResize();
+}
+
+
+
+void UI::AdjustTextDisplay() const
+{
+	for(auto &it : stack)
+		it->DoUpdateTextDisplay();
 }
 
 

--- a/source/UI.h
+++ b/source/UI.h
@@ -93,6 +93,7 @@ public:
 	bool IsEmpty() const;
 
 	void AdjustViewport() const;
+	void AdjustTextDisplay() const;
 
 	// Get the current mouse position.
 	static Point GetMouse();

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -359,6 +359,11 @@ void GameLoop(PlayerInfo &player, TaskQueue &queue, const Conversation &conversa
 				menuPanels.AdjustViewport();
 				gamePanels.AdjustViewport();
 			}
+			else if(event.type == CustomEvents::GetAdjustText())
+			{
+				menuPanels.AdjustTextDisplay();
+				gamePanels.AdjustTextDisplay();
+			}
 			else if(event.type == SDL_KEYDOWN && !toggleTimeout
 					&& (Command(event.key.keysym.sym).Has(Command::FULLSCREEN)
 					|| (event.key.keysym.sym == SDLK_RETURN && (event.key.keysym.mod & KMOD_ALT))))

--- a/source/text/Alignment.h
+++ b/source/text/Alignment.h
@@ -17,7 +17,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 // Ways in which text may be aligned.
 enum class Alignment : int {
-	LEFT,
+	LEFT = 0,
 	CENTER,
 	RIGHT,
 	JUSTIFIED,

--- a/source/text/WrappedText.cpp
+++ b/source/text/WrappedText.cpp
@@ -332,30 +332,18 @@ void WrappedText::AdjustLine(size_t &lineBegin, int &lineWidth, bool isEnd)
 	if(lineWidth > longestLineWidth)
 		longestLineWidth = lineWidth;
 
-	Alignment finalAlignment;
-	Preferences::AlignmentOverride alignmentOverride = Preferences::GetAlignmentOverride();
-	if(alignmentOverride == Preferences::AlignmentOverride::LEFT)
-		finalAlignment = Alignment::LEFT;
-	else if(alignmentOverride == Preferences::AlignmentOverride::CENTER)
-		finalAlignment = Alignment::CENTER;
-	else if(alignmentOverride == Preferences::AlignmentOverride::RIGHT)
-		finalAlignment = Alignment::RIGHT;
-	else if(alignmentOverride == Preferences::AlignmentOverride::JUSTIFIED)
-		finalAlignment = Alignment::JUSTIFIED;
-	else
-		finalAlignment = alignment;
 	// Figure out how much space is left over. Depending on the alignment, we
 	// will add that space to the left, to the right, to both sides, or to the
 	// space in between the words. Exception: the last line of a "justified"
 	// paragraph is left aligned, not justified.
-	if(finalAlignment == Alignment::JUSTIFIED && !isEnd && wordCount > 1)
+	if(alignment == Alignment::JUSTIFIED && !isEnd && wordCount > 1)
 	{
 		for(int i = 0; i < wordCount; ++i)
 			words[lineBegin + i].x += extraSpace * i / (wordCount - 1);
 	}
-	else if(finalAlignment == Alignment::CENTER || finalAlignment == Alignment::RIGHT)
+	else if(alignment == Alignment::CENTER || alignment == Alignment::RIGHT)
 	{
-		int shift = (finalAlignment == Alignment::CENTER) ? extraSpace / 2 : extraSpace;
+		int shift = (alignment == Alignment::CENTER) ? extraSpace / 2 : extraSpace;
 		for(int i = 0; i < wordCount; ++i)
 			words[lineBegin + i].x += shift;
 	}


### PR DESCRIPTION
Changes the text alignment preference to not impact tooltips and WrappedTrext created by interface data. All other WrappedText and TextAreas created directly by Panels are using the preference.